### PR TITLE
feat [mumu]: PR 알림에 작성자 Slack 멘션 추가

### DIFF
--- a/servers/mumu/src/github/pull_request.ts
+++ b/servers/mumu/src/github/pull_request.ts
@@ -34,12 +34,16 @@ export const handlePullRequest = (pullRequest: PullRequest, slackNotifier: Slack
     return JSON.stringify({ success: true, message: "Pull request closed." });
   }
 
-  const reviewers = selectReviewers(config.admins, pullRequest.pull_request.user.login, 3);
+  const authorLogin = pullRequest.pull_request.user.login;
+  const author = config.admins.find((admin) => admin.github === authorLogin);
+  const authorMention = author ? `<@${author.slack}>` : authorLogin;
+
+  const reviewers = selectReviewers(config.admins, authorLogin, 3);
   const mentions = reviewers.map((r) => `<@${r.slack}>`).join(", ");
   const text = [
     `*[${repoFullName}]에서 PR이 올라왔어요!* 👀`,
     `> *PR:* <${pullRequest.pull_request.html_url}|#${prNumber} ${pullRequest.pull_request.title}>`,
-    `> *작성자:* ${pullRequest.pull_request.user.login}`,
+    `> *작성자:* ${authorMention}`,
     `> *리뷰어:* ${mentions}`,
   ].join("\n");
 


### PR DESCRIPTION
## 작업 내용

- PR 생성 알림 메시지에서 작성자를 GitHub 로그인 대신 Slack 멘션으로 표시하도록 변경
- admins 목록에 없는 외부 기여자인 경우 GitHub 로그인명으로 fallback 처리

Made with [Cursor](https://cursor.com)