### PR TITLE
feat [mumu]: 피그마 플러그인 CORS 설정 추가

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
       '@slack/web-api':
         specifier: ^7.0.0
         version: 7.14.1
+      cors:
+        specifier: ^2.8.6
+        version: 2.8.6
       dotenv:
         specifier: ^16.4.0
         version: 16.6.1
@@ -116,6 +119,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@types/cors':
+        specifier: ^2.8.19
+        version: 2.8.19
       '@types/express':
         specifier: ^5.0.0
         version: 5.0.6
@@ -407,6 +413,9 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
+  '@types/cors@2.8.19':
+    resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
+
   '@types/express-serve-static-core@5.1.1':
     resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
 
@@ -518,6 +527,10 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -763,6 +776,10 @@ packages:
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -1175,6 +1192,10 @@ snapshots:
     dependencies:
       '@types/node': 25.3.2
 
+  '@types/cors@2.8.19':
+    dependencies:
+      '@types/node': 25.3.2
+
   '@types/express-serve-static-core@5.1.1':
     dependencies:
       '@types/node': 25.3.2
@@ -1299,6 +1320,11 @@ snapshots:
   cookie-signature@1.0.7: {}
 
   cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   debug@2.6.9:
     dependencies:
@@ -1569,6 +1595,8 @@ snapshots:
   ms@2.1.3: {}
 
   negotiator@0.6.3: {}
+
+  object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
 

--- a/servers/mumu/package.json
+++ b/servers/mumu/package.json
@@ -9,19 +9,21 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@makers-devops/redis": "workspace:*",
-    "@makers-devops/slack": "workspace:*",
-    "@makers-devops/shared": "workspace:*",
-    "@makers-devops/github": "workspace:*",
     "@makers-devops/figma": "workspace:*",
+    "@makers-devops/github": "workspace:*",
+    "@makers-devops/redis": "workspace:*",
+    "@makers-devops/shared": "workspace:*",
+    "@makers-devops/slack": "workspace:*",
     "@makers-devops/slack-blocks": "workspace:*",
     "@slack/web-api": "^7.0.0",
+    "cors": "^2.8.6",
     "dotenv": "^16.4.0",
     "express": "^4.21.0",
     "tsx": "^4.19.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.19",
     "@types/express": "^5.0.0"
   }
 }

--- a/servers/mumu/src/index.ts
+++ b/servers/mumu/src/index.ts
@@ -1,5 +1,6 @@
 import "dotenv/config";
 import express from "express";
+import cors from "cors";
 import { createWebhookRouter } from "./webhook";
 import { assertNonNullish } from "@makers-devops/shared";
 
@@ -19,6 +20,15 @@ const necessaryEnvVars = [
 for (const envVar of necessaryEnvVars) {
   assertNonNullish(process.env[envVar], `${envVar} is not set`);
 }
+
+/** Figma 플러그인 요청 허용 */
+app.use(
+  cors({
+    origin: "null",
+    methods: ["POST", "OPTIONS"],
+    allowedHeaders: ["Content-Type"],
+  }),
+);
 
 /** 요청 JSON 바디 파싱 */
 app.use(express.json());


### PR DESCRIPTION
## 작업 내용

- 피그마 플러그인의 `Origin: null` 요청을 허용하기 위해 `cors` 미들웨어 추가
- `Content-Type: application/json` preflight(OPTIONS) 요청 자동 처리 설정

Made with [Cursor](https://cursor.com)