### PR TITLE
feat [mumu, slack-blocks]: 디자인 리뷰 요청 시 슬랙 멘션 및 챕터별 config 분리

### DIFF
--- a/packages/slack-blocks/src/index.ts
+++ b/packages/slack-blocks/src/index.ts
@@ -1,5 +1,6 @@
 export type { SlackBlockPayload } from "./types";
 export type { PR열림Options } from "./PR/PR_열림";
+export type { 리뷰요청Options } from "./피그마/리뷰_요청";
 
 export * as PR_열림 from "./PR/PR_열림";
 export * as PR_닫힘 from "./PR/PR_닫힘";

--- a/packages/slack-blocks/src/피그마/리뷰_요청.ts
+++ b/packages/slack-blocks/src/피그마/리뷰_요청.ts
@@ -2,14 +2,20 @@ import type { KnownBlock } from "@slack/types";
 import type { DesignReviewRequestBody } from "@makers-devops/figma";
 import type { SlackBlockPayload } from "../types";
 
-export const blocks = (payload: DesignReviewRequestBody): KnownBlock[] => {
-  const { userName, task, schedule, reviewPoints, fileUrl } = payload;
+export type 리뷰요청Options = {
+  slackId: string;
+};
+
+export const blocks = (payload: DesignReviewRequestBody, options: 리뷰요청Options): KnownBlock[] => {
+  const { task, schedule, reviewPoints, fileUrl } = payload;
+  const authorDisplay = `<@${options.slackId}>`;
+
   return [
     {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `*${userName}* 님의 [디자인 리뷰 요청]`,
+        text: `${authorDisplay} 님의 [디자인 리뷰 요청]`,
       },
     },
     {
@@ -32,7 +38,7 @@ export const fallbackText = (payload: DesignReviewRequestBody): string => {
   return `${userName}님의 [디자인 리뷰 요청]`;
 };
 
-export const slackPayload = (payload: DesignReviewRequestBody): SlackBlockPayload => ({
+export const slackPayload = (payload: DesignReviewRequestBody, options: 리뷰요청Options): SlackBlockPayload => ({
   text: fallbackText(payload),
-  blocks: blocks(payload),
+  blocks: blocks(payload, options),
 });

--- a/servers/mumu/raw/config.json
+++ b/servers/mumu/raw/config.json
@@ -1,41 +1,86 @@
 {
-  "admins": [
-    {
-      "github": "wuzoo",
-      "slack": "U07HP891PQW"
-    },
-    {
-      "github": "namdaeun",
-      "slack": "U08EL9ABEPK"
-    },
-    {
-      "github": "constantly-dev",
-      "slack": "U09CF6MG3SS"
-    },
-    {
-      "github": "jeonghoon11",
-      "slack": "U0AHNG8ST2M"
-    },
-    {
-      "github": "sonnnnhe",
-      "slack": "U0AH66C3LAZ"
-    },
-    {
-      "github": "jogpfls",
-      "slack": "U0AH3773LG3"
-    },
-    {
-      "github": "ExceptAnyone",
-      "slack": "U0AGU5C6E87"
-    }
-  ],
-  "repos": [
-    "makers-devops",
-    "sopt-makers-frontend",
-    "sopt-operation-frontend",
-    "sopt-recruiting-frontend",
-    "sopt.org-frontend",
-    "makers-design-system-2.0",
-    "sopt-auth-frontend"
-  ]
+  "frontend": {
+    "admins": [
+      {
+        "name": "최주용",
+        "github": "wuzoo",
+        "slack": "U07HP891PQW"
+      },
+      {
+        "name": "남다은",
+        "github": "namdaeun",
+        "slack": "U08EL9ABEPK"
+      },
+      {
+        "name": "이진혁",
+        "github": "constantly-dev",
+        "slack": "U09CF6MG3SS"
+      },
+      {
+        "name": "장정훈",
+        "github": "jeonghoon11",
+        "slack": "U0AHNG8ST2M"
+      },
+      {
+        "name": "손하은",
+        "github": "sonnnnhe",
+        "slack": "U0AH66C3LAZ"
+      },
+      {
+        "name": "조혜린",
+        "github": "jogpfls",
+        "slack": "U0AH3773LG3"
+      },
+      {
+        "name": "장정안",
+        "github": "ExceptAnyone",
+        "slack": "U0AGU5C6E87"
+      }
+    ],
+    "repos": [
+      "makers-devops",
+      "sopt-makers-frontend",
+      "sopt-operation-frontend",
+      "sopt-recruiting-frontend",
+      "sopt.org-frontend",
+      "makers-design-system-2.0",
+      "sopt-auth-frontend"
+    ]
+  },
+  "design": {
+    "admins": [
+      {
+        "name": "이유지",
+        "slack": "U08EL9AT56D"
+      },
+      {
+        "name": "장린",
+        "slack": "U09CF6WUZ2S"
+      },
+      {
+        "name": "손은서",
+        "slack": "U04QEPWDVA9"
+      },
+      {
+        "name": "전희주",
+        "slack": "U09CF6XAXFG"
+      },
+      {
+        "name": "김희재",
+        "slack": "U0AHD77TV1S"
+      },
+      {
+        "name": "하수정",
+        "slack": "U0AH7GSE7UN"
+      },
+      {
+        "name": "이미영",
+        "slack": "U0AH374DY8K"
+      },
+      {
+        "name": "이재영",
+        "slack": "U08E51Z5NR3"
+      }
+    ]
+  }
 }

--- a/servers/mumu/src/config.ts
+++ b/servers/mumu/src/config.ts
@@ -21,5 +21,5 @@ export const config = loadConfig();
 export function isValidRepository(repo: string | null | undefined) {
   if (repo == null) return false;
 
-  return config.repos.includes(repo);
+  return config.frontend.repos.includes(repo);
 }

--- a/servers/mumu/src/github/review.ts
+++ b/servers/mumu/src/github/review.ts
@@ -1,6 +1,6 @@
 import { githubClient } from "@makers-devops/github";
 import { MAKERS_OWNER } from "../constant";
-import type { AdminUser } from "../types";
+import type { Developer } from "../types";
 
 export async function assignReviewers(repo: string, prNumber: number, reviewers: string[]) {
   const response = await githubClient.pulls.requestReviewers({
@@ -13,7 +13,7 @@ export async function assignReviewers(repo: string, prNumber: number, reviewers:
   return response;
 }
 
-export function selectReviewers(admins: AdminUser[], excludeUser: string, count = 3): AdminUser[] {
+export function selectReviewers(admins: Developer[], excludeUser: string, count = 3): Developer[] {
   const candidates = admins.filter((admin) => admin.github !== excludeUser);
 
   // Fisher-Yates shuffle

--- a/servers/mumu/src/handler/figma-plugin/design-review.ts
+++ b/servers/mumu/src/handler/figma-plugin/design-review.ts
@@ -3,6 +3,11 @@ import { slackClient } from "@makers-devops/slack";
 import type { Request, Response } from "express";
 import { CHANNELS } from "../../constant";
 import { 피그마_리뷰_요청 } from "@makers-devops/slack-blocks";
+import { config } from "../../config";
+
+const findDesignAdminByName = (name: string) => {
+  return config.design.admins.find((admin) => admin.name === name) ?? null;
+};
 
 export const handleDesignReview = async (req: Request, res: Response) => {
   const result = designReviewRequestBodySchema.safeParse(req.body);
@@ -11,11 +16,16 @@ export const handleDesignReview = async (req: Request, res: Response) => {
     return res.status(400).json({ success: false, message: "Bad Request" });
   }
 
+  const admin = findDesignAdminByName(result.data.userName);
+
+  if (!admin) {
+    return res.status(403).json({ success: false, message: "등록되지 않은 사용자입니다." });
+  }
+
   try {
     await slackClient.chat.postMessage({
-      /** TODO(@wuzoo): 테스트 후 채널 변경 */
       channel: CHANNELS.DESIGN_REVIEW,
-      ...피그마_리뷰_요청.slackPayload(result.data),
+      ...피그마_리뷰_요청.slackPayload(result.data, { slackId: admin.slack }),
     });
   } catch {
     return res.status(500).json({ success: false, message: "Internal Server Error" });

--- a/servers/mumu/src/handler/github-webhook/pull_request.ts
+++ b/servers/mumu/src/handler/github-webhook/pull_request.ts
@@ -51,13 +51,13 @@ export const handlePullRequest = async (req: Request, res: Response) => {
   }
 
   const authorLogin = pullRequest.pull_request.user.login;
-  const author = config.admins.find((admin) => admin.github === authorLogin);
+  const author = config.frontend.admins.find((admin) => admin.github === authorLogin);
 
   if (!author) {
     return res.json({ success: false, message: "Author is not admin user" });
   }
 
-  const reviewers = selectReviewers(config.admins, authorLogin, 3);
+  const reviewers = selectReviewers(config.frontend.admins, authorLogin, 3);
   const reviewerGithubIds = reviewers.map((r) => r.github);
   const reviewerSlackIds = reviewers.map((r) => r.slack);
 

--- a/servers/mumu/src/types.ts
+++ b/servers/mumu/src/types.ts
@@ -1,14 +1,22 @@
-export type AdminUser = {
-  github: string;
+export type Member = {
+  name: string;
   slack: string;
 };
 
-export type RepositoryConfig = {
-  repo: string;
-  admins: AdminUser[];
+export type Developer = Member & {
+  github: string;
+};
+
+export type FrontendConfig = {
+  admins: Developer[];
+  repos: string[];
+};
+
+export type DesignConfig = {
+  admins: Member[];
 };
 
 export type Config = {
-  admins: AdminUser[];
-  repos: string[];
+  frontend: FrontendConfig;
+  design: DesignConfig;
 };


### PR DESCRIPTION
## 작업 내용

- config.json 구조를 frontend/design 챕터별로 분리하고 멤버 name 필드 추가
- Member, Developer 타입을 도입하여 챕터별 멤버 타입 체계 정리
- 디자인 리뷰 요청 슬랙 알림에서 userName 대신 슬랙 멘션으로 표시되도록 개선
- 미등록 사용자의 디자인 리뷰 요청 시 403 응답 반환

Made with [Cursor](https://cursor.com)