### PR TITLE
chore [slack-blocks]: 디자인 리뷰 Figma 링크를 하이퍼링크로 변경

### DIFF
--- a/packages/slack-blocks/src/피그마/리뷰_요청.ts
+++ b/packages/slack-blocks/src/피그마/리뷰_요청.ts
@@ -25,7 +25,7 @@ export const blocks = (payload: DesignReviewRequestBody, options: 리뷰요청Op
         text: [
           `> *작업:* ${task}`,
           `> *리뷰 요청 일정:* ~${schedule}`,
-          `> *Figma:* <${fileUrl}|${fileUrl}>`,
+          `> *Figma:* <${fileUrl}|링크 바로가기>`,
           `> *리뷰 요청 포인트:* ${reviewPoints}`,
         ].join("\n"),
       },


### PR DESCRIPTION
## 작업 내용

- 디자인 리뷰 슬랙 알림의 Figma URL을 전체 표시 대신 `링크 바로가기` 하이퍼링크로 변경

Made with [Cursor](https://cursor.com)