### PR TITLE
fix [slack-blocks]: 디자인 리뷰 요청 포인트 줄바꿈 시 인용 블록 깨짐 수정

### DIFF
--- a/packages/slack-blocks/src/피그마/리뷰_요청.ts
+++ b/packages/slack-blocks/src/피그마/리뷰_요청.ts
@@ -26,7 +26,7 @@ export const blocks = (payload: DesignReviewRequestBody, options: 리뷰요청Op
           `> *작업:* ${task}`,
           `> *리뷰 요청 일정:* ~${schedule}`,
           `> *Figma:* <${fileUrl}|링크 바로가기>`,
-          `> *리뷰 요청 포인트:* ${reviewPoints}`,
+          `> *리뷰 요청 포인트:* ${reviewPoints.replace(/\n/g, "\n> ")}`,
         ].join("\n"),
       },
     },


### PR DESCRIPTION
## 작업 내용

- 리뷰 요청 포인트(`reviewPoints`)에 줄바꿈이 포함될 경우 Slack 인용 블록(`>`)이 첫 줄에만 적용되어 이후 줄의 들여쓰기가 풀리는 문제 수정
- `reviewPoints` 내 모든 줄바꿈에 `> ` 접두사를 추가하여 전체 내용이 인용 블록 안에 유지되도록 개선

Made with [Cursor](https://cursor.com)