### PR TITLE
feat [mumu]: Slack DM UX Writing 리뷰 지원

### DIFF
--- a/servers/mumu/src/slack/bot/listener.ts
+++ b/servers/mumu/src/slack/bot/listener.ts
@@ -1,4 +1,4 @@
-import type { App } from "@slack/bolt";
+import type { App, Logger } from "@slack/bolt";
 import { formatUxReviewForSlack, reviewUxWriting } from "../../ai";
 
 /** 멘션 텍스트에서 봇 멘션(<@U123>)을 제거한다. */
@@ -7,7 +7,10 @@ const stripMention = (text: string): string => text.replace(/<@[A-Z0-9]+>/g, "")
 const LOADING_REACTION = "loading";
 const DONE_REACTION = "white_check_mark";
 
-type SlackReactionClient = {
+type SlackChatClient = {
+  chat: {
+    postMessage: (args: { channel: string; thread_ts?: string; text: string }) => Promise<unknown>;
+  };
   reactions: {
     add: (args: { channel: string; timestamp: string; name: string }) => Promise<unknown>;
     remove: (args: { channel: string; timestamp: string; name: string }) => Promise<unknown>;
@@ -17,11 +20,15 @@ type SlackReactionClient = {
 const HELP_MESSAGE = [
   "*mumu UX Writing 리뷰 봇*",
   "",
-  "검토하고 싶은 문구나 맥락을 멘션과 함께 보내주세요.",
-  '예) `@mumu 결제 실패 화면에 "오류가 발생했습니다" 라고 띄우려는데 괜찮을까?`',
+  "검토하고 싶은 문구나 맥락을 보내주세요.",
+  "",
+  "• 채널: `@무무봇` 멘션과 함께 전송",
+  '  예) `@무무봇 결제 실패 화면에 "오류가 발생했습니다" 라고 띄우려는데 괜찮을까?`',
+  "• DM: 무무봇과의 대화에서 바로 전송",
+  '  예) `결제 실패 화면에 "오류가 발생했습니다" 라고 띄우려는데 괜찮을까?`',
 ].join("\n");
 
-const addReaction = async (client: SlackReactionClient, channel: string, timestamp: string, name: string) => {
+const addReaction = async (client: SlackChatClient, channel: string, timestamp: string, name: string) => {
   try {
     await client.reactions.add({ channel, timestamp, name });
   } catch (error) {
@@ -29,11 +36,53 @@ const addReaction = async (client: SlackReactionClient, channel: string, timesta
   }
 };
 
-const removeReaction = async (client: SlackReactionClient, channel: string, timestamp: string, name: string) => {
+const removeReaction = async (client: SlackChatClient, channel: string, timestamp: string, name: string) => {
   try {
     await client.reactions.remove({ channel, timestamp, name });
   } catch (error) {
     console.error(`reaction remove failed (${name}):`, error);
+  }
+};
+
+type ReviewRequest = {
+  channel: string;
+  messageTs: string;
+  threadTs: string;
+  text: string;
+};
+
+const handleUxWritingReview = async (client: SlackChatClient, logger: Logger, request: ReviewRequest) => {
+  const { channel, messageTs, threadTs, text } = request;
+  const query = stripMention(text);
+
+  if (query === "") {
+    await client.chat.postMessage({ channel, thread_ts: threadTs, text: HELP_MESSAGE });
+    return;
+  }
+
+  await addReaction(client, channel, messageTs, LOADING_REACTION);
+
+  try {
+    const result = await reviewUxWriting(query);
+
+    await client.chat.postMessage({
+      channel,
+      thread_ts: threadTs,
+      text: formatUxReviewForSlack(result),
+    });
+
+    await removeReaction(client, channel, messageTs, LOADING_REACTION);
+    await addReaction(client, channel, messageTs, DONE_REACTION);
+  } catch (error) {
+    logger.error(error);
+
+    await removeReaction(client, channel, messageTs, LOADING_REACTION);
+
+    await client.chat.postMessage({
+      channel,
+      thread_ts: threadTs,
+      text: "검토 중 문제가 발생했어요. 잠시 후 다시 시도해주세요.",
+    });
   }
 };
 
@@ -43,39 +92,32 @@ export const registerSlackBotListeners = (app: App): void => {
       return;
     }
 
-    const channel = event.channel;
-    const messageTs = event.ts;
-    const threadTs = event.thread_ts ?? event.ts;
-    const query = stripMention(event.text);
+    await handleUxWritingReview(client, logger, {
+      channel: event.channel,
+      messageTs: event.ts,
+      threadTs: event.thread_ts ?? event.ts,
+      text: event.text,
+    });
+  });
 
-    if (query === "") {
-      await client.chat.postMessage({ channel, thread_ts: threadTs, text: HELP_MESSAGE });
+  app.message(async ({ message, client, logger }) => {
+    if (message.channel_type !== "im") {
       return;
     }
 
-    await addReaction(client, channel, messageTs, LOADING_REACTION);
-
-    try {
-      const result = await reviewUxWriting(query);
-
-      await client.chat.postMessage({
-        channel,
-        thread_ts: threadTs,
-        text: formatUxReviewForSlack(result),
-      });
-
-      await removeReaction(client, channel, messageTs, LOADING_REACTION);
-      await addReaction(client, channel, messageTs, DONE_REACTION);
-    } catch (error) {
-      logger.error(error);
-
-      await removeReaction(client, channel, messageTs, LOADING_REACTION);
-
-      await client.chat.postMessage({
-        channel,
-        thread_ts: threadTs,
-        text: "검토 중 문제가 발생했어요. 잠시 후 다시 시도해주세요.",
-      });
+    if (message.subtype || ("bot_id" in message && message.bot_id)) {
+      return;
     }
+
+    if (!("text" in message) || !message.text || !message.ts) {
+      return;
+    }
+
+    await handleUxWritingReview(client, logger, {
+      channel: message.channel,
+      messageTs: message.ts,
+      threadTs: message.thread_ts ?? message.ts,
+      text: message.text,
+    });
   });
 };


### PR DESCRIPTION
## 작업 내용

- 무무봇과의 DM 메시지로 UX Writing 리뷰를 요청할 수 있도록 지원
- 채널 멘션과 DM에서 공통 리뷰 처리 로직을 사용하도록 개선
- 봇 메시지와 메시지 변경 이벤트를 제외하여 중복 처리 방지
- 도움말에 채널 멘션 및 DM 사용 방법 추가